### PR TITLE
Change lightshow modes & add new lightshow mode

### DIFF
--- a/src/core/lighting/basic-light.ts
+++ b/src/core/lighting/basic-light.ts
@@ -13,10 +13,12 @@ import { easingFromId, easingFromName, type EasingFunction } from '../easing';
 const lightGradientSchema = z.record(z.string(), beatSaberJsonValueSchema);
 
 export type BasicLightColor = 'red' | 'blue' | 'white';
-export type LightshowMode = 'full' | 'full-lightshow' | 'static' | 'none';
+export type LightshowMode = 'full' | 'lightshow' | 'full-lightshow' | 'static' | 'none';
 
-export const isFullLightshowMode = (mode: LightshowMode) => mode === 'full' || mode === 'full-lightshow';
-export const isForcedLightshowMode = (mode: LightshowMode) => mode === 'full-lightshow';
+export const isFullLightshowMode = (mode: LightshowMode) =>
+  mode === 'full' || mode === 'lightshow' || mode === 'full-lightshow';
+export const isForcedLightshowMode = (mode: LightshowMode) => mode === 'lightshow' || mode === 'full-lightshow';
+export const isLightsOnlyMode = (mode: LightshowMode) => mode === 'full-lightshow';
 
 export interface BasicLightSample {
   color: BasicLightColor;

--- a/src/core/placement/map-render-data.ts
+++ b/src/core/placement/map-render-data.ts
@@ -53,6 +53,7 @@ export interface BombInstance extends ObjectMotion {
 export interface WallInstance extends ObjectMotion {
   x: number;
   y: number;
+  interactable: boolean;
   rotationDeg: number;
   width: number;
   height: number;
@@ -445,6 +446,7 @@ export function buildMapRenderData(difficulty: Difficulty, options: MapRenderOpt
       ...motion,
       x: options.leftHanded === true ? -placement.x : placement.x,
       y: placement.y,
+      interactable: !obstacle.customFake && heck.canBecomeInteractable(obstacle),
       rotationDeg: worldRotation === undefined ? obstacle.rotation * (options.leftHanded === true ? -1 : 1) : 0,
       width: placement.width,
       height: placement.height,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -390,9 +390,11 @@
       "increaseNumerator": "Increase numerator",
       "increaseNumeratorLabel": "Increase beat step numerator",
       "lighting": {
-        "force": "Full (Force Lightshow)",
         "full": "Full",
-        "label": "Lighting mode"
+        "label": "Lighting mode",
+        "lightsOnly": "Lights Only",
+        "lightshow": "Lightshow",
+        "off": "Off"
       },
       "localFilesUnavailable": "Local files cannot be shared",
       "masterVolume": "Master volume",

--- a/src/modules/viewer/transport/lightshow-menu.tsx
+++ b/src/modules/viewer/transport/lightshow-menu.tsx
@@ -29,6 +29,7 @@ export function LightshowMenu({
   function selectMode(value: string) {
     switch (value) {
       case 'full-lightshow':
+      case 'lightshow':
       case 'full':
       case 'static':
       case 'none':
@@ -57,7 +58,10 @@ export function LightshowMenu({
         onValueChange={selectMode}
       >
         <ToggleGroupItem className="w-full" value="full-lightshow">
-          {t('force')}
+          {t('lightsOnly')}
+        </ToggleGroupItem>
+        <ToggleGroupItem className="w-full" value="lightshow">
+          {t('lightshow')}
         </ToggleGroupItem>
         <ToggleGroupItem className="w-full" value="full">
           {t('full')}
@@ -66,7 +70,7 @@ export function LightshowMenu({
           {tc('static')}
         </ToggleGroupItem>
         <ToggleGroupItem className="w-full" value="none">
-          {tc('off')}
+          {t('off')}
         </ToggleGroupItem>
       </ToggleGroup>
     </TransportMenu>

--- a/src/modules/viewer/use-viewer-session.ts
+++ b/src/modules/viewer/use-viewer-session.ts
@@ -403,7 +403,7 @@ export function useViewerSession({
   }
 
   function cycleLights() {
-    const modes: LightshowMode[] = ['full-lightshow', 'full', 'static', 'none'];
+    const modes: LightshowMode[] = ['none', 'static', 'full', 'lightshow', 'full-lightshow'];
     const next = modes[(modes.indexOf(lightshowMode) + 1) % modes.length] ?? 'full';
     changeLightshowMode(next);
   }

--- a/src/modules/viewer/viewer-search.ts
+++ b/src/modules/viewer/viewer-search.ts
@@ -46,7 +46,7 @@ export const viewerSearchSchema = z.pipe(
     characteristic: z.catch(z.optional(characteristicSchema), undefined),
     beat: z.catch(z.optional(nonnegativeNumberSchema), undefined),
     autoplay: z.catch(z.optional(z.boolean()), undefined),
-    lightshow: z.catch(z.optional(z.literal('full-lightshow')), undefined),
+    lightshow: z.catch(z.optional(z.enum(['lightshow', 'full-lightshow'])), undefined),
     settings: z.catch(z.optional(viewerSettingsPatchSchema), undefined),
     playerId: z.catch(z.optional(livePlayerIdSchema), undefined),
     tournamentId: z.catch(z.optional(liveIdSchema), undefined),
@@ -114,7 +114,7 @@ export function viewerSearchForShare(
   source: ViewerShareSource,
   beat: number | undefined,
   settings?: SharedViewerSettings,
-  lightshow?: 'full-lightshow',
+  lightshow?: 'lightshow' | 'full-lightshow',
 ): ViewerSearch {
   if (source.type === 'live') {
     return {

--- a/src/modules/watch-party/watch-party-viewer-settings.ts
+++ b/src/modules/watch-party/watch-party-viewer-settings.ts
@@ -12,7 +12,7 @@ const watchPartyViewerSettingsSchema = z.object({
   previewHitNotes: z.boolean(),
   previewHitLine: z.boolean(),
   previewNotesLookAtPlayer: z.boolean(),
-  lightshowMode: z.enum(['full', 'full-lightshow', 'static', 'none']),
+  lightshowMode: z.enum(['full', 'lightshow', 'full-lightshow', 'static', 'none']),
   preferReplayColors: z.boolean(),
   preferReplayEnvironment: z.boolean(),
   overrideEnvironment: z.boolean(),

--- a/src/renderer/map-view.ts
+++ b/src/renderer/map-view.ts
@@ -6,7 +6,7 @@ import { songBpmTimeToSeconds } from '../core/beatmap/bpm';
 import type { InfoColorScheme } from '../core/beatmap/info';
 import type { ChromaEnvironmentData } from '../core/chroma-environment';
 import { DEFAULT_COLORS, resolveColorScheme, type ColorScheme, type Rgb } from '../core/colors';
-import { isForcedLightshowMode, type LightshowMode } from '../core/lighting/basic-light';
+import { isForcedLightshowMode, isLightsOnlyMode, type LightshowMode } from '../core/lighting/basic-light';
 import { sampleNoodlePlayerTrack } from '../core/noodle-runtime';
 import { applyReplayHeightEvents, applyReplayNoteEvents, type MapRenderData } from '../core/placement/map-render-data';
 import type { HitScoreVisualizerConfig } from '../core/replay/hit-score-visualizer';
@@ -245,8 +245,8 @@ export class MapView implements RenderView {
   setLightshowMode(mode: LightshowMode) {
     this.lightshowMode = mode;
     this.environmentLights.setLightshowMode(mode);
-    const forced = isForcedLightshowMode(mode);
-    this.mapRoot.visible = !forced;
+    this.mapRoot.visible = !isLightsOnlyMode(mode);
+    this.mapObjects.setGameplayObjectsVisible(mode !== 'lightshow');
     this.replayView.setLightshowMode(mode);
     this.mapObjects.invalidate();
   }
@@ -406,7 +406,7 @@ export class MapView implements RenderView {
       if (fog !== undefined) this.pipeline.setFogParams(fog);
     }
     if (data === null) return;
-    if (isForcedLightshowMode(this.lightshowMode)) return;
+    if (isLightsOnlyMode(this.lightshowMode)) return;
     const replayTime = songBpmTimeToSeconds(now, data.songBpm);
     this.playerCameraRoot.position.set(0, 0, 0);
     this.playerCameraRoot.quaternion.identity();

--- a/src/renderer/map/map-object-renderer.ts
+++ b/src/renderer/map/map-object-renderer.ts
@@ -170,6 +170,7 @@ export class MapObjectRenderer {
   private previewHitNotes = true;
   private previewHitLine = false;
   private previewNotesLookAtPlayer = false;
+  private gameplayObjectsVisible = true;
   private instanceGroups: InstancedGroup[] = [];
   private arcEntries: ArcEntry[] = [];
   private noteReplayWindows: ActiveWindowIndex | null = null;
@@ -418,6 +419,12 @@ export class MapObjectRenderer {
     this.invalidate();
   }
 
+  setGameplayObjectsVisible(visible: boolean) {
+    if (visible === this.gameplayObjectsVisible) return;
+    this.gameplayObjectsVisible = visible;
+    this.invalidate();
+  }
+
   invalidate() {
     this.objectBeat = Number.NaN;
     this.noteLookStates.clear();
@@ -441,7 +448,7 @@ export class MapObjectRenderer {
     for (const group of this.instanceGroups) group.begin();
     const replayLoaded = replayView.hasReplay;
     const hitPreviewNotes = !replayLoaded && this.previewHitNotes;
-    this.hitLine.visible = !replayLoaded && this.previewHitLine;
+    this.hitLine.visible = this.gameplayObjectsVisible && !replayLoaded && this.previewHitLine;
     const poseFrames = replayView.poseFrames;
 
     const activeNotes = this.noteReplayWindows?.at(now) ?? [];
@@ -449,6 +456,7 @@ export class MapObjectRenderer {
       for (const index of activeNotes) {
         const note = data.notes[index];
         if (note?.colorIndex !== colorIndex) continue;
+        if (!this.gameplayObjectsVisible) continue;
         const duration = currentHalfJumpDurationInBeats(note, movementState) * 2;
         const noodle = sampleNoodleRenderObject(note, data.noodle, now, duration, context, data.leftHanded);
         const movementBeat = noodleMovementBeat(note, now, noodle, duration);
@@ -531,6 +539,7 @@ export class MapObjectRenderer {
     for (const index of this.bombWindows?.at(now) ?? []) {
       const bomb = data.bombs[index];
       if (bomb === undefined) continue;
+      if (!this.gameplayObjectsVisible) continue;
       const duration = currentHalfJumpDurationInBeats(bomb, movementState) * 2;
       const noodle = sampleNoodleRenderObject(bomb, data.noodle, now, duration, context, data.leftHanded);
       const movementBeat = noodleMovementBeat(bomb, now, noodle, duration);
@@ -573,6 +582,7 @@ export class MapObjectRenderer {
       for (const index of activeLinks) {
         const link = data.chainLinks[index];
         if (link?.colorIndex !== colorIndex) continue;
+        if (!this.gameplayObjectsVisible) continue;
         const duration = currentHalfJumpDurationInBeats(link, movementState) * 2;
         const noodle = sampleNoodleRenderObject(link, data.noodle, now, duration, context, data.leftHanded);
         const movementBeat = noodleMovementBeat(link, now, noodle, duration);
@@ -614,6 +624,7 @@ export class MapObjectRenderer {
     for (const index of this.wallWindows?.at(now) ?? []) {
       const wall = data.walls[index];
       if (wall === undefined) continue;
+      if (!this.gameplayObjectsVisible && wall.interactable) continue;
       const duration =
         currentHalfJumpDurationInBeats(wall, movementState) * 2 + (wall.durationBeats ?? wall.pullBeat - wall.beat);
       const noodle = sampleNoodleRenderObject(wall, data.noodle, now, duration, context, data.leftHanded);
@@ -729,6 +740,7 @@ export class MapObjectRenderer {
       const entry = this.arcEntries[index];
       if (entry === undefined) continue;
       const arc = entry.arc;
+      if (!this.gameplayObjectsVisible) continue;
       const hjdBeats = arc.usesGlobalNjs ? movementState.halfJumpDurationInBeats : arc.hjdBeats;
       const unitsPerBeat = arc.usesGlobalNjs
         ? movementState.halfJumpDistance / movementState.halfJumpDurationInBeats


### PR DESCRIPTION
The `Full (Force Lightshow)` mode is now called `Lights Only` and a new `Lightshow` mode has been added.

In `Lightshow` mode notes, bombs, arcs, chains, and interactable walls are hidden. Fake or uninteractable decorative walls are visible so Noodle/Chroma lightshow effects render.

The existing `full-lightshow` value now represents `Lights Only`. Its behaviour is unchanged so older configs continue to work. 